### PR TITLE
18 not all database queries are logged

### DIFF
--- a/src/EventSubscriber/RequestSubscriber.php
+++ b/src/EventSubscriber/RequestSubscriber.php
@@ -249,7 +249,7 @@ class RequestSubscriber implements EventSubscriberInterface {
         'abs_path' => $query['caller']['file'],
         'filename' => substr($query['caller']['file'], strrpos($query['caller']['file'], '/') + 1),
         'lineno' => $query['caller']['line'],
-        'vars' => $query['args'],
+        'vars' => (object) $query['args'],
       ],
     ];
 

--- a/src/EventSubscriber/RequestSubscriber.php
+++ b/src/EventSubscriber/RequestSubscriber.php
@@ -132,7 +132,7 @@ class RequestSubscriber implements EventSubscriberInterface {
 
     // Start a new transaction.
     try {
-      $transaction = $this->phpAgent->startTransaction();
+      $transaction = $this->phpAgent->startTransaction($this->routeMatch->getRouteName());
     }
     catch (Exception $e) {
       // Log the error to watchdog.

--- a/src/EventSubscriber/RequestSubscriber.php
+++ b/src/EventSubscriber/RequestSubscriber.php
@@ -132,10 +132,7 @@ class RequestSubscriber implements EventSubscriberInterface {
 
     // Start a new transaction.
     try {
-      $transaction = $this->phpAgent->startTransaction($this->routeMatch->getRouteName());
-
-      // Capture database time by wrapping spans around the db queries run.
-      $transaction->setSpans($this->constructDatabaseSpans());
+      $transaction = $this->phpAgent->startTransaction();
     }
     catch (Exception $e) {
       // Log the error to watchdog.
@@ -174,7 +171,11 @@ class RequestSubscriber implements EventSubscriberInterface {
 
     // End the transaction.
     try {
-      $this->phpAgent->stopTransaction($this->routeMatch->getRouteName());
+      $transaction = $this->phpAgent->getTransaction($this->routeMatch->getRouteName());
+      // Capture database time by wrapping spans around the db queries run.
+      $transaction->setSpans($this->constructDatabaseSpans());
+
+      $transaction->stop();
 
       // Send our transaction to Elastic.
       $this->phpAgent->send();


### PR DESCRIPTION
This moves the function that creates a span for every query from the `REQUEST` event to `FINISH_REQUEST`.

This needs testing (I haven't even tried it yet) and is also not the best event for this to happen in but #17 is already addressing that by switching from `FINISH_REQUEST` to `TERMINATE`.